### PR TITLE
Dotenv package: Only use in local environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@
 */
 
 // read local environment variables
-require('dotenv').config();
+if (process.env.LOCAL || false) {
+  require('dotenv').config();
+}
 
 const express = require('express');
 // PARSE SERVER (https://github.com/parse-community/parse-server/wiki)


### PR DESCRIPTION
Include `dotenv` only on local environments since it will not be installed on Heroku